### PR TITLE
Clean up callback hell

### DIFF
--- a/app/commands/interact.go
+++ b/app/commands/interact.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"github.com/kjkondratuk/goblins-and-gold/app/state"
 	"github.com/kjkondratuk/goblins-and-gold/app/ux"
-	"github.com/kjkondratuk/goblins-and-gold/container"
-	interaction2 "github.com/kjkondratuk/goblins-and-gold/interaction"
+	"github.com/kjkondratuk/goblins-and-gold/interaction"
 	"github.com/pterm/pterm"
 	"github.com/urfave/cli"
+	"reflect"
 )
 
 func Interact(s *state.State) cli.ActionFunc {
@@ -15,70 +15,57 @@ func Interact(s *state.State) cli.ActionFunc {
 		if len(c.Args()) == 0 {
 			// coerce to ux.Described
 			ia := s.CurrRoom.Containers
-			d := make([]ux.Described, len(ia))
+			if len(ia) <= 0 {
+				return nil
+			}
+			dCon := make([]ux.Described, len(ia))
 			for i, a := range ia {
-				d[i] = a
+				dCon[i] = a
 			}
 
 			// Pass the available containers on context to the interactionData selector
-			c := context.WithValue(context.Background(), interaction2.InteractionDataKey, s.CurrRoom.Containers)
-			c = context.WithValue(c, interaction2.PlayerDataKey, s.Player)
+			//c := context.WithValue(context.Background(), interaction.InteractionDataKey, s.CurrRoom.Containers)
+			//p := context.WithValue(context.Background(), interaction.PlayerDataKey, s.Player)
 
 			// Prompt for selection of the interactable
-			result, err := ux.NewSelector("None of these", "Interact with", interactionSelector).Run(c, d)
+			interactIdx, _, err := ux.NewSelector("None of these", "Interact with").Run(dCon)
 			// handle errors with creating the selector for item ia
 			if err != nil {
 				return err
 			}
 
+			// Prompt for selection of the action
+			dAct := make([]ux.Described, len(ia[interactIdx].SupportedInteractions))
+			for i, a := range ia[interactIdx].SupportedInteractions {
+				dAct[i] = a
+			}
+			_, actStr, err := ux.NewSelector("Cancel", "Actions").Run(dAct)
+
+			a := interaction.Type(actStr)
+
+			// get interactions available for this container
+			result, err := ia[interactIdx].Do(context.WithValue(context.Background(), interaction.PlayerDataKey, s.Player), a)
+			if err != nil {
+				return err
+			}
+
 			// Apply to game state, if there was an applicable result
-			if result != nil {
-				r := result.(interaction2.Result)
-				s.Apply(r)
-				switch r.Type {
-				case interaction2.RT_Success:
-					pterm.Success.Println(r.Message)
-				case interaction2.RT_Failure:
-					pterm.Error.Println(r.Message)
+			emptyResult := interaction.Result{}
+			if !reflect.DeepEqual(result, emptyResult) {
+				//r := result.(interaction.Result)
+				s.Apply(result)
+				switch result.Type {
+				case interaction.RT_Success:
+					pterm.Success.Println(result.Message)
+				case interaction.RT_Failure:
+					pterm.Error.Println(result.Message)
 				default:
-					if r.Message != "" {
-						pterm.Info.Println(r.Message)
+					if result.Message != "" {
+						pterm.Info.Println(result.Message)
 					}
 				}
 			}
 		}
 		return nil
 	}
-}
-
-// actionSelector : Selects an actionItemData to take upon a given item provided a context containing both the
-func actionSelector(ctx context.Context, idx int, val string, err error) (interface{}, error) {
-	a := interaction2.Type(val)
-
-	// get interactions available for this container
-	containerInteractions := ctx.Value(interaction2.ContainerDataKey).(*container.Container)
-
-	result, err := containerInteractions.Do(ctx, a)
-	if err != nil {
-		return interaction2.Result{}, err
-	}
-
-	return result, nil
-}
-
-// interactionSelector : Selects an object to interact with provided a context with interactables.  Further
-// prompts a user for the actionItemData they'd like to take on the item based on its supported interactions.
-func interactionSelector(ctx context.Context, idx int, val string, err error) (interface{}, error) {
-	//pterm.Success.Printf("Selected: %s\n", val)
-	selection := ctx.Value(interaction2.InteractionDataKey).([]*container.Container)[idx-1]
-
-	// coerce to ux.Described
-	ia := selection.SupportedInteractions
-	d := make([]ux.Described, len(ia))
-	for i, a := range ia {
-		d[i] = a
-	}
-
-	// Prompt for selection of the actionItemData
-	return ux.NewSelector("Cancel", "Actions", actionSelector).Run(context.WithValue(ctx, interaction2.ContainerDataKey, selection), d)
 }

--- a/app/commands/interact.go
+++ b/app/commands/interact.go
@@ -40,6 +40,9 @@ func Interact(s *state.State) cli.ActionFunc {
 				dAct[i] = a
 			}
 			_, actStr, err := ux.NewSelector("Cancel", "Actions").Run(dAct)
+			if actStr == "" {
+				return nil
+			}
 
 			a := interaction.Type(actStr)
 

--- a/app/ux/select.go
+++ b/app/ux/select.go
@@ -1,7 +1,6 @@
 package ux
 
 import (
-	"context"
 	"github.com/manifoldco/promptui"
 )
 
@@ -9,27 +8,27 @@ type Described interface {
 	Describe() string
 }
 
-type SelectAction func(ctx context.Context, idx int, val string, err error) (interface{}, error)
+//type SelectAction func(ctx context.Context, idx int, val string, err error) (interface{}, error)
 
 type selector struct {
-	cancel  string
-	label   string
-	handler SelectAction
+	cancel string
+	label  string
+	//handler SelectAction
 }
 
 type Select interface {
-	Run(ctx context.Context, items []Described) (interface{}, error)
+	Run( /*ctx context.Context, */ items []Described) ( /*interface{}*/ int, string, error)
 }
 
-func NewSelector(c string, l string, h SelectAction) Select {
+func NewSelector(c string, l string /*, h SelectAction*/) Select {
 	return &selector{
-		cancel:  c,
-		label:   l,
-		handler: h,
+		cancel: c,
+		label:  l,
+		//handler: h,
 	}
 }
 
-func (c *selector) Run(ctx context.Context, items []Described) (interface{}, error) {
+func (c *selector) Run( /*ctx context.Context, */ items []Described) ( /*interface{}*/ int, string, error) {
 	var options []string
 	options = append(options, c.cancel)
 	for _, i := range items {
@@ -38,7 +37,8 @@ func (c *selector) Run(ctx context.Context, items []Described) (interface{}, err
 	p := promptui.Select{Label: c.label, Items: options}
 	i, v, err := p.Run()
 	if i > 0 {
-		return c.handler(ctx, i, v, err)
+		// use i-1 because we added a cancel option
+		return /*c.handler(ctx, */ i - 1, v, err /*)*/
 	}
-	return nil, nil
+	return 0, "", nil
 }

--- a/app/ux/select.go
+++ b/app/ux/select.go
@@ -8,27 +8,23 @@ type Described interface {
 	Describe() string
 }
 
-//type SelectAction func(ctx context.Context, idx int, val string, err error) (interface{}, error)
-
 type selector struct {
 	cancel string
 	label  string
-	//handler SelectAction
 }
 
 type Select interface {
-	Run( /*ctx context.Context, */ items []Described) ( /*interface{}*/ int, string, error)
+	Run(items []Described) (int, string, error)
 }
 
-func NewSelector(c string, l string /*, h SelectAction*/) Select {
+func NewSelector(c string, l string) Select {
 	return &selector{
 		cancel: c,
 		label:  l,
-		//handler: h,
 	}
 }
 
-func (c *selector) Run( /*ctx context.Context, */ items []Described) ( /*interface{}*/ int, string, error) {
+func (c *selector) Run(items []Described) (int, string, error) {
 	var options []string
 	options = append(options, c.cancel)
 	for _, i := range items {
@@ -38,7 +34,7 @@ func (c *selector) Run( /*ctx context.Context, */ items []Described) ( /*interfa
 	i, v, err := p.Run()
 	if i > 0 {
 		// use i-1 because we added a cancel option
-		return /*c.handler(ctx, */ i - 1, v, err /*)*/
+		return i - 1, v, err
 	}
 	return 0, "", nil
 }

--- a/container/container.go
+++ b/container/container.go
@@ -79,24 +79,19 @@ func (c *Container) loot(ctx context.Context) (interaction.Result, error) {
 			d[i] = x
 		}
 
-		result, err := ux.NewSelector("Cancel", "Items", func(ctx context.Context, idx int, val string, err error) (interface{}, error) {
-			it := c.Items[idx-1]
-			c.Items = c.removeItem(idx - 1)
-
-			return interaction.Result{
-				Type:          interaction.RT_Success,
-				Message:       fmt.Sprintf("You successfully looted: %s\n", it.Description),
-				AcquiredItems: []item.Item{it},
-			}, nil
-		}).Run(ctx, d)
-
-		var val interaction.Result
-		if result == nil {
-			val = interaction.Result{}
-		} else {
-			val = result.(interaction.Result)
+		resultIdx, _, err := ux.NewSelector("Cancel", "Items").Run(d)
+		if err != nil {
+			return interaction.Result{}, err
 		}
-		return val, err
+		// TODO : getting an error here when looting the small chest and then cancelling
+		it := c.Items[resultIdx]
+		c.Items = c.removeItem(resultIdx)
+
+		return interaction.Result{
+			Type:          interaction.RT_Success,
+			Message:       fmt.Sprintf("You successfully looted: %s\n", it.Description),
+			AcquiredItems: []item.Item{it},
+		}, nil
 	} else {
 		return interaction.Result{
 			Type:    interaction.RT_Failure,
@@ -113,6 +108,7 @@ func (c *Container) unlock(ctx context.Context) (interaction.Result, error) {
 		}, nil
 	}
 
+	// TODO : should probably validate the context before we do it.
 	p := ctx.Value(interaction.PlayerDataKey).(actors.Player)
 	// Get skill check type: c.Locked.Type
 	// Get the player's modifier for the specified skill

--- a/container/container.go
+++ b/container/container.go
@@ -74,24 +74,31 @@ func (c *Container) open(ctx context.Context) (interaction.Result, error) {
 
 func (c *Container) loot(ctx context.Context) (interaction.Result, error) {
 	if c.Locked == nil {
-		d := make([]ux.Described, len(c.Items))
-		for i, x := range c.Items {
-			d[i] = x
-		}
+		if len(c.Items) > 0 {
+			d := make([]ux.Described, len(c.Items))
+			for i, x := range c.Items {
+				d[i] = x
+			}
 
-		resultIdx, _, err := ux.NewSelector("Cancel", "Items").Run(d)
-		if err != nil {
-			return interaction.Result{}, err
-		}
-		// TODO : getting an error here when looting the small chest and then cancelling
-		it := c.Items[resultIdx]
-		c.Items = c.removeItem(resultIdx)
+			resultIdx, _, err := ux.NewSelector("Cancel", "Items").Run(d)
+			if err != nil {
+				return interaction.Result{}, err
+			}
+			// TODO : getting an error here when looting the small chest and then cancelling
+			it := c.Items[resultIdx]
+			c.Items = c.removeItem(resultIdx)
 
-		return interaction.Result{
-			Type:          interaction.RT_Success,
-			Message:       fmt.Sprintf("You successfully looted: %s\n", it.Description),
-			AcquiredItems: []item.Item{it},
-		}, nil
+			return interaction.Result{
+				Type:          interaction.RT_Success,
+				Message:       fmt.Sprintf("You successfully looted: %s\n", it.Description),
+				AcquiredItems: []item.Item{it},
+			}, nil
+		} else {
+			return interaction.Result{
+				Type:    interaction.RT_Failure,
+				Message: "No items to loot.  The container is empty.",
+			}, nil
+		}
 	} else {
 		return interaction.Result{
 			Type:    interaction.RT_Failure,

--- a/data/monsters.yaml
+++ b/data/monsters.yaml
@@ -37,12 +37,40 @@ monsters:
             damage_type: Slashing
           - roll: 2d6
             damage_type: Necrotic
-# TODO : Add ability to add multi-attacks -- probably need a custom parser for this
-#      multiattack:
-#        - number: 1
-#          attacks:
-#            - *death-slaad-bite
-#        - number: 2
-#          attacks:
-#            - *death-slaad-claws
-#            - *death-slaad-greatsword
+  # TODO : Add ability to add multi-attacks -- probably need a custom parser for this
+  #      multiattack:
+  #        - number: 1
+  #          attacks:
+  #            - *death-slaad-bite
+  #        - number: 2
+  #          attacks:
+  #            - *death-slaad-claws
+  #            - *death-slaad-greatsword
+  goblin: &goblin
+    name: Goblin
+    ac: 15
+    hp: 7
+    stats:
+      str: 8
+      dex: 14
+      con: 10
+      int: 10
+      wis: 8
+      cha: 8
+    inventory: []
+    attacks:
+      scimitar: &goblin-scimitar
+        bonus: 4
+        range: 5
+        damage:
+          - roll: 1d6
+            bonus: 2
+            damage_type: Slashing
+      shortbow: &goblin-shortbow
+        bonus: 4
+        range: 80
+        falloff: 320
+        damage:
+          - roll: 1d6
+            bonus: 2
+            damage_type: Piercing

--- a/data/worlds/test_world.yaml
+++ b/data/worlds/test_world.yaml
@@ -16,7 +16,8 @@ rooms:
       - type: Combat
         description: A hulking dark figure rises from the floor ahead of you.  You brace for combat.
         enemies:
-          - *death-slaad
+#          - *death-slaad
+          - *goblin
   treasure-room-1:
     name: Treasure Room
     description: There are three chests located against the far wall.

--- a/encounter/encounter.go
+++ b/encounter/encounter.go
@@ -1,7 +1,6 @@
 package encounter
 
 import (
-	"context"
 	"github.com/kjkondratuk/goblins-and-gold/actors"
 	"github.com/kjkondratuk/goblins-and-gold/app/ux"
 	"github.com/pterm/pterm"
@@ -76,11 +75,7 @@ func (e *encounter) Run(p actors.Player) Outcome {
 			switch c.(type) {
 			case actors.Player:
 				// take player turn
-				// TODO : figure out how to handle the deeply nested nature of combat--it makes it difficult to check stats and such as combat progresses
-				_, _ = ux.NewSelector("Pass", "How do you respond?", func(ctx context.Context, idx int, val string, err error) (interface{}, error) {
-					//_, _ = ux.NewSelector("Back")
-					return nil, nil
-				}).Run(context.Background(), combatActions)
+				_, _, _ = ux.NewSelector("Pass", "How do you respond?").Run(combatActions)
 			case actors.Monster:
 				// take monster turn
 				c.Attack(p)


### PR DESCRIPTION
I was using callbacks for selects instead of running them sequentially.  This made it really hard to reason about what was populated in the context and what was not.  Now, the only thing we need the context for is the player information when attempting to unlock and apply a skill check--this still seems a little weird, but we'll live with it for now.